### PR TITLE
Add bilingual language switcher with translations

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,27 +23,55 @@
   <header>
     <div class="container nav">
       <div class="brand">
-        <a href="#top" class="brand" aria-label="QICB 홈으로">
+        <a href="#top" class="brand" aria-label="QICB 홈으로" data-i18n-aria-label="brand.homeAria">
           <img class="brand-logo" src="assets/logo-qicb.png" alt="QICB Logo" />
-          <span>QICB Fall Fest 2025 @ PNU</span>
+          <span data-i18n="brand.name">QICB Fall Fest 2025 @ PNU</span>
         </a>
       </div>
-      <button class="nav-toggle" type="button" aria-controls="primary-nav-menu" aria-expanded="false">
-        <span class="sr-only">주요 메뉴 열기</span>
-        <span class="nav-toggle-icon" aria-hidden="true"></span>
-      </button>
       <nav class="primary-nav" aria-label="Primary">
         <div id="primary-nav-menu" class="nav-menu" data-open="false" aria-hidden="true" tabindex="-1">
-          <a class="btn" href="#about" aria-current="page" ia-current="page">소개</a> <a class="btn"
-            href="#schedule">일정</a>
-          <a class="btn" href="#venue">장소</a>
-          <a class="btn" href="#faq">FAQ</a>
-          <a class="btn-primary" href="https://forms.gle/your-register-link" target="_blank" rel="noopener">
+          <a class="btn" href="#about" aria-current="page" ia-current="page" data-i18n="nav.about">소개</a>
+          <a class="btn" href="#schedule" data-i18n="nav.schedule">일정</a>
+          <a class="btn" href="#venue" data-i18n="nav.venue">장소</a>
+          <a class="btn" href="#faq" data-i18n="nav.faq">FAQ</a>
+          <a class="btn-primary" href="https://forms.gle/your-register-link" target="_blank" rel="noopener"
+            data-i18n="nav.register">
             지금 등록하기
             <span aria-hidden="true">→</span>
           </a>
         </div>
       </nav>
+      <div class="nav-actions">
+        <div class="language-dropdown" data-open="false">
+          <button class="language-button" type="button" aria-haspopup="true" aria-expanded="false"
+            data-i18n-aria-label="language.button.aria">
+            <span class="language-flag" aria-hidden="true">🇰🇷</span>
+            <span class="language-code">KR</span>
+          </button>
+          <ul class="language-menu" role="menu" aria-label="언어 선택" data-i18n-aria-label="language.menu.aria"
+            aria-hidden="true">
+            <li role="none">
+              <button type="button" class="language-option" role="menuitemradio" aria-checked="true"
+                data-lang="ko">
+                <span class="language-flag" aria-hidden="true">🇰🇷</span>
+                <span class="language-name" data-i18n="language.option.ko">한국어 (KR)</span>
+              </button>
+            </li>
+            <li role="none">
+              <button type="button" class="language-option" role="menuitemradio" aria-checked="false"
+                data-lang="en">
+                <span class="language-flag" aria-hidden="true">🇺🇸</span>
+                <span class="language-name" data-i18n="language.option.en">영어 (EN)</span>
+              </button>
+            </li>
+          </ul>
+        </div>
+        <button class="nav-toggle" type="button" aria-controls="primary-nav-menu" aria-expanded="false"
+          aria-label="주요 메뉴 열기" data-i18n-aria-label="nav.toggle">
+          <span class="sr-only" data-i18n="nav.toggle">주요 메뉴 열기</span>
+          <span class="nav-toggle-icon" aria-hidden="true"></span>
+        </button>
+      </div>
     </div>
   </header>
 
@@ -57,12 +85,12 @@
             fetchpriority="high" />
           <div class="hero-copy">
             <h1>Qiskit Fall Fest 2025<br />PNU</h1>
-            <p class="sub">2025.11.21 (금) · 부산대학교</p>
+            <p class="sub" data-i18n="hero.date">2025.11.21 (금) · 부산대학교</p>
             <div class="kpis" style="margin-top:14px">
-              <span>⏱️ 세션 & 실습</span>
-              <span>🧪 Qiskit 핸즈온</span>
-              <span>🏆 미니 챌린지</span>
-              <span>👥 네트워킹</span>
+              <span data-i18n="hero.kpi.sessions">⏱️ 세션 & 실습</span>
+              <span data-i18n="hero.kpi.handsOn">🧪 Qiskit 핸즈온</span>
+              <span data-i18n="hero.kpi.challenge">🏆 미니 챌린지</span>
+              <span data-i18n="hero.kpi.networking">👥 네트워킹</span>
             </div>
           </div>
         </div>
@@ -72,18 +100,18 @@
     <!-- ABOUT -->
     <section id="about" class="anchor">
       <div class="container">
-        <h2>행사 소개</h2>
+        <h2 data-i18n="about.title">행사 소개</h2>
         <div class="panel">
-          <p>
+          <p data-i18n="about.description" data-i18n-type="html">
             <strong>Qiskit Fall Fest 2025 @ PNU</strong>는 <strong>QICB(Quantum Information Club in Busan)</strong>가
             주최하고,
             <strong> IBM Quantum</strong>의 글로벌 Fall Fest 프로그램의 일환으로 개최되는 행사입니다.
             양자 컴퓨팅을 처음 접하는 초보자들을 위한 자리이며, 강연·실습·네트워킹을 통해 양자 컴퓨팅을 배울 수 있는 기회를 제공합니다.
           </p>
           <ul class="list">
-            <li><strong>대상:</strong> 컴공/물리/수학 전공자 및 비전공자 모두</li>
-            <li><strong>준비물:</strong> 노트북, GitHub 계정, 기본 Python 환경</li>
-            <li><strong>난이도:</strong> 입문~초급 (사전 자료 제공)</li>
+            <li data-i18n="about.audience" data-i18n-type="html"><strong>대상:</strong> 컴공/물리/수학 전공자 및 비전공자 모두</li>
+            <li data-i18n="about.requirements" data-i18n-type="html"><strong>준비물:</strong> 노트북, GitHub 계정, 기본 Python 환경</li>
+            <li data-i18n="about.level" data-i18n-type="html"><strong>난이도:</strong> 입문~초급 (사전 자료 제공)</li>
           </ul>
         </div>
       </div>
@@ -92,33 +120,33 @@
     <!-- SCHEDULE -->
     <section id="schedule" class="anchor">
       <div class="container">
-        <h2>일정(안)</h2>
+        <h2 data-i18n="schedule.title">일정(안)</h2>
         <div class="grid cols-2">
           <div class="panel">
             <span class="tag">Part 1</span>
-            <h3 style="margin:8px 0 6px">Hands-on & Mini Hack</h3>
+            <h3 style="margin:8px 0 6px" data-i18n="schedule.part1.title">Hands-on & Mini Hack</h3>
             <ul class="list">
-              <li>10:00 - 10:30 · Fall Fest Opening</li>
-              <li>10:30 - 11:30 · 스피커 초청 연사</li>
-              <li>13:00 - 14:00 · Qiskit Fundamental Lab</li>
-              <li>14:00 - 16:00 · Mini Hack</li>
+              <li data-i18n="schedule.part1.item1">10:00 - 10:30 · Fall Fest Opening</li>
+              <li data-i18n="schedule.part1.item2">10:30 - 11:30 · 스피커 초청 연사</li>
+              <li data-i18n="schedule.part1.item3">13:00 - 14:00 · Qiskit Fundamental Lab</li>
+              <li data-i18n="schedule.part1.item4">14:00 - 16:00 · Mini Hack</li>
             </ul>
           </div>
           <div class="panel">
             <span class="tag">Part 2</span>
-            <h3 style="margin:8px 0 6px">Workshop</h3>
+            <h3 style="margin:8px 0 6px" data-i18n="schedule.part2.title">Workshop</h3>
             <ul class="list">
-              <li>16:00 - 17:00 · 워크숍 1</li>
-              <li>17:00 - 18:00 · 워크숍 2</li>
-              <li>18:00 - 18:30 · Fall Fest Closing</li>
+              <li data-i18n="schedule.part2.item1">16:00 - 17:00 · 워크숍 1</li>
+              <li data-i18n="schedule.part2.item2">17:00 - 18:00 · 워크숍 2</li>
+              <li data-i18n="schedule.part2.item3">18:00 - 18:30 · Fall Fest Closing</li>
             </ul>
           </div>
         </div>
         <div class="center" style="margin-top:14px">
-          <a class="btn-primary" href="https://forms.gle/your-register-link" target="_blank" rel="noopener">사전 등록하기</a>
+          <a class="btn-primary" href="https://forms.gle/your-register-link" target="_blank" rel="noopener" data-i18n="cta.preregister">사전 등록하기</a>
           <a class="btn-ghost"
             href="https://resilient-tilapia-077.notion.site/Qiskit-Fall-Fest-2025-PNU-25ac026b5ea48028b5abc79156f12cba?source=copy_link"
-            target="_blank" rel="noopener">상세 안내(노션)</a>
+            target="_blank" rel="noopener" data-i18n="cta.moreInfo">상세 안내(노션)</a>
         </div>
       </div>
     </section>
@@ -126,10 +154,10 @@
     <!-- VENUE -->
     <section id="venue" class="anchor">
       <div class="container">
-        <h2>장소</h2>
+        <h2 data-i18n="venue.title">장소</h2>
         <div class="panel">
-          <p><strong>부산대학교 제6공학관(컴퓨터공학관)</strong><br />부산광역시 금정구 부산대학로63번길 2 (장전동)</p>
-          <p class="muted">세부 호실/입장 동선은 행사 전 참가자 안내 메일로 공지됩니다.</p>
+          <p data-i18n="venue.address" data-i18n-type="html"><strong>부산대학교 제6공학관(컴퓨터공학관)</strong><br />부산광역시 금정구 부산대학로63번길 2 (장전동)</p>
+          <p class="muted" data-i18n="venue.note">세부 호실/입장 동선은 행사 전 참가자 안내 메일로 공지됩니다.</p>
         </div>
       </div>
     </section>
@@ -137,23 +165,23 @@
     <!-- FAQ -->
     <section id="faq" class="anchor">
       <div class="container">
-        <h2>FAQ</h2>
+        <h2 data-i18n="faq.title">FAQ</h2>
         <div class="grid cols-2">
           <div class="panel">
-            <strong>비전공자도 참여 가능한가요?</strong>
-            <p class="muted">네. 사전 자료를 제공하고, 실습은 튜터가 함께 돕습니다.</p>
+            <strong data-i18n="faq.q1">비전공자도 참여 가능한가요?</strong>
+            <p class="muted" data-i18n="faq.a1">네. 사전 자료를 제공하고, 실습은 튜터가 함께 돕습니다.</p>
           </div>
           <div class="panel">
-            <strong>참가비가 있나요?</strong>
-            <p class="muted">무료입니다. 사전 등록만 해주세요.</p>
+            <strong data-i18n="faq.q2">참가비가 있나요?</strong>
+            <p class="muted" data-i18n="faq.a2">무료입니다. 사전 등록만 해주세요.</p>
           </div>
           <div class="panel">
-            <strong>무엇을 설치해야 하나요?</strong>
-            <p class="muted">Python 3.10+과 최신 Qiskit. 자세한 가이드는 노션 페이지에서 안내합니다.</p>
+            <strong data-i18n="faq.q3">무엇을 설치해야 하나요?</strong>
+            <p class="muted" data-i18n="faq.a3">Python 3.10+과 최신 Qiskit. 자세한 가이드는 노션 페이지에서 안내합니다.</p>
           </div>
           <div class="panel">
-            <strong>팀을 미리 구성해야 하나요?</strong>
-            <p class="muted">필수는 아니며, 현장에서도 매칭을 도와드립니다.</p>
+            <strong data-i18n="faq.q4">팀을 미리 구성해야 하나요?</strong>
+            <p class="muted" data-i18n="faq.a4">필수는 아니며, 현장에서도 매칭을 도와드립니다.</p>
           </div>
         </div>
       </div>
@@ -162,14 +190,14 @@
 
   <footer>
     <div class="container center" style="justify-content:space-between;flex-wrap:wrap">
-      <div>© 2025 QICB · Quantum Information Club in Busan</div>
+      <div data-i18n="footer.copy">© 2025 QICB · Quantum Information Club in Busan</div>
       <div class="center" style="gap:8px">
-        <a class="btn" href="mailto:qicb.club@gmail.com">이메일 문의</a>
-        <a class="btn" href="https://github.com/qicb-git/qicb-fallfest-2025" target="_blank" rel="noopener">GitHub</a>
+        <a class="btn" href="mailto:qicb.club@gmail.com" data-i18n="footer.email">이메일 문의</a>
+        <a class="btn" href="https://github.com/qicb-git/qicb-fallfest-2025" target="_blank" rel="noopener" data-i18n="footer.github">GitHub</a>
       </div>
     </div>
   </footer>
-  <button id="scrollTopBtn" aria-label="맨 위로 이동">
+  <button id="scrollTopBtn" aria-label="맨 위로 이동" data-i18n-aria-label="scrollTop.aria">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
       stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M12 19V5M5 12l7-7 7 7" />

--- a/main.js
+++ b/main.js
@@ -1,3 +1,406 @@
+const LANGUAGE_STORAGE_KEY = 'qicb-preferred-language';
+
+const LANGUAGE_OPTIONS = {
+  ko: { code: 'KR', flag: '🇰🇷' },
+  en: { code: 'EN', flag: '🇺🇸' }
+};
+
+const translations = {
+  ko: {
+    'brand.name': 'QICB Fall Fest 2025 @ PNU',
+    'brand.homeAria': 'QICB 홈으로',
+    'nav.about': '소개',
+    'nav.schedule': '일정',
+    'nav.venue': '장소',
+    'nav.faq': 'FAQ',
+    'nav.register': '지금 등록하기',
+    'nav.toggle': '주요 메뉴 열기',
+    'hero.date': '2025.11.21 (금) · 부산대학교',
+    'hero.kpi.sessions': '⏱️ 세션 & 실습',
+    'hero.kpi.handsOn': '🧪 Qiskit 핸즈온',
+    'hero.kpi.challenge': '🏆 미니 챌린지',
+    'hero.kpi.networking': '👥 네트워킹',
+    'about.title': '행사 소개',
+    'about.description':
+      '<strong>Qiskit Fall Fest 2025 @ PNU</strong>는 <strong>QICB(Quantum Information Club in Busan)</strong>가 주최하고, <strong>IBM Quantum</strong>의 글로벌 Fall Fest 프로그램의 일환으로 개최되는 행사입니다. 양자 컴퓨팅을 처음 접하는 초보자들을 위한 자리이며, 강연·실습·네트워킹을 통해 양자 컴퓨팅을 배울 수 있는 기회를 제공합니다.',
+    'about.audience': '<strong>대상:</strong> 컴공/물리/수학 전공자 및 비전공자 모두',
+    'about.requirements': '<strong>준비물:</strong> 노트북, GitHub 계정, 기본 Python 환경',
+    'about.level': '<strong>난이도:</strong> 입문~초급 (사전 자료 제공)',
+    'schedule.title': '일정(안)',
+    'schedule.part1.title': 'Hands-on & Mini Hack',
+    'schedule.part1.item1': '10:00 - 10:30 · Fall Fest Opening',
+    'schedule.part1.item2': '10:30 - 11:30 · 스피커 초청 연사',
+    'schedule.part1.item3': '13:00 - 14:00 · Qiskit Fundamental Lab',
+    'schedule.part1.item4': '14:00 - 16:00 · Mini Hack',
+    'schedule.part2.title': 'Workshop',
+    'schedule.part2.item1': '16:00 - 17:00 · 워크숍 1',
+    'schedule.part2.item2': '17:00 - 18:00 · 워크숍 2',
+    'schedule.part2.item3': '18:00 - 18:30 · Fall Fest Closing',
+    'cta.preregister': '사전 등록하기',
+    'cta.moreInfo': '상세 안내(노션)',
+    'venue.title': '장소',
+    'venue.address':
+      '<strong>부산대학교 제6공학관(컴퓨터공학관)</strong><br />부산광역시 금정구 부산대학로63번길 2 (장전동)',
+    'venue.note': '세부 호실/입장 동선은 행사 전 참가자 안내 메일로 공지됩니다.',
+    'faq.title': 'FAQ',
+    'faq.q1': '비전공자도 참여 가능한가요?',
+    'faq.a1': '네. 사전 자료를 제공하고, 실습은 튜터가 함께 돕습니다.',
+    'faq.q2': '참가비가 있나요?',
+    'faq.a2': '무료입니다. 사전 등록만 해주세요.',
+    'faq.q3': '무엇을 설치해야 하나요?',
+    'faq.a3': 'Python 3.10+과 최신 Qiskit. 자세한 가이드는 노션 페이지에서 안내합니다.',
+    'faq.q4': '팀을 미리 구성해야 하나요?',
+    'faq.a4': '필수는 아니며, 현장에서도 매칭을 도와드립니다.',
+    'footer.copy': '© 2025 QICB · Quantum Information Club in Busan',
+    'footer.email': '이메일 문의',
+    'footer.github': 'GitHub',
+    'scrollTop.aria': '맨 위로 이동',
+    'language.button.aria': '언어 변경',
+    'language.menu.aria': '언어 선택',
+    'language.option.ko': '한국어 (KR)',
+    'language.option.en': '영어 (EN)',
+    'meta.title': 'QICB Fall Fest 2025 | 부산',
+    'meta.description': 'QICB가 주최하는 Qiskit Fall Fest 2025 - 부산. 해커톤·세미나·워크숍을 통해 양자 컴퓨팅을 함께 배웁니다.',
+    'meta.ogTitle': 'QICB Fall Fest 2025 | 부산',
+    'meta.ogDescription': '양자 컴퓨팅을 함께 배우는 해커톤/세션. 지금 등록하세요!',
+    'meta.ogLocale': 'ko_KR'
+  },
+  en: {
+    'brand.name': 'QICB Fall Fest 2025 @ PNU',
+    'brand.homeAria': 'Go to QICB home',
+    'nav.about': 'About',
+    'nav.schedule': 'Schedule',
+    'nav.venue': 'Venue',
+    'nav.faq': 'FAQ',
+    'nav.register': 'Register Now',
+    'nav.toggle': 'Open main menu',
+    'hero.date': 'Nov 21, 2025 (Fri) · Pusan National University',
+    'hero.kpi.sessions': '⏱️ Sessions & Labs',
+    'hero.kpi.handsOn': '🧪 Qiskit Hands-on',
+    'hero.kpi.challenge': '🏆 Mini Challenge',
+    'hero.kpi.networking': '👥 Networking',
+    'about.title': 'About the Event',
+    'about.description':
+      '<strong>Qiskit Fall Fest 2025 @ PNU</strong> is hosted by <strong>QICB (Quantum Information Club in Busan)</strong> as part of the global Fall Fest program by <strong>IBM Quantum</strong>. It welcomes newcomers to quantum computing and offers talks, hands-on labs, and networking opportunities to learn together.',
+    'about.audience': '<strong>Who:</strong> Students and enthusiasts across CS, physics, math, and beyond',
+    'about.requirements': '<strong>What to bring:</strong> Laptop, GitHub account, basic Python setup',
+    'about.level': '<strong>Level:</strong> Beginner–intro (prep materials provided)',
+    'schedule.title': 'Schedule (TBD)',
+    'schedule.part1.title': 'Hands-on & Mini Hack',
+    'schedule.part1.item1': '10:00 - 10:30 · Fall Fest Opening',
+    'schedule.part1.item2': '10:30 - 11:30 · Guest speaker session',
+    'schedule.part1.item3': '13:00 - 14:00 · Qiskit Fundamental Lab',
+    'schedule.part1.item4': '14:00 - 16:00 · Mini Hack',
+    'schedule.part2.title': 'Workshops',
+    'schedule.part2.item1': '16:00 - 17:00 · Workshop 1',
+    'schedule.part2.item2': '17:00 - 18:00 · Workshop 2',
+    'schedule.part2.item3': '18:00 - 18:30 · Fall Fest Closing',
+    'cta.preregister': 'Pre-register',
+    'cta.moreInfo': 'More info (Notion)',
+    'venue.title': 'Venue',
+    'venue.address':
+      '<strong>Pusan National University, Engineering Building 6 (Computer Engineering)</strong><br />2, Busandaehak-ro 63beon-gil, Geumjeong-gu, Busan',
+    'venue.note': 'Room details and entry guidance will be emailed to participants before the event.',
+    'faq.title': 'FAQ',
+    'faq.q1': 'Can non-majors participate?',
+    'faq.a1': 'Yes! Prep materials are shared and tutors will support you during the labs.',
+    'faq.q2': 'Is there a participation fee?',
+    'faq.a2': 'No, it’s free. Just make sure to register in advance.',
+    'faq.q3': 'What should I install beforehand?',
+    'faq.a3': 'Install Python 3.10+ and the latest Qiskit. Detailed setup guides are on the Notion page.',
+    'faq.q4': 'Do I need a team beforehand?',
+    'faq.a4': 'Teams are optional—we can help you form one on-site.',
+    'footer.copy': '© 2025 QICB · Quantum Information Club in Busan',
+    'footer.email': 'Email us',
+    'footer.github': 'GitHub',
+    'scrollTop.aria': 'Back to top',
+    'language.button.aria': 'Change language',
+    'language.menu.aria': 'Select language',
+    'language.option.ko': 'Korean (KR)',
+    'language.option.en': 'English (EN)',
+    'meta.title': 'QICB Fall Fest 2025 | Busan',
+    'meta.description': 'Join the Qiskit Fall Fest 2025 in Busan hosted by QICB with hackathons, talks, and workshops to learn quantum computing.',
+    'meta.ogTitle': 'QICB Fall Fest 2025 | Busan',
+    'meta.ogDescription': 'Learn quantum computing together through sessions, hands-on labs, and networking—register now!',
+    'meta.ogLocale': 'en_US'
+  }
+};
+
+const getInitialLanguage = () => {
+  try {
+    const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+    if (stored && translations[stored]) {
+      return stored;
+    }
+  } catch (error) {
+    // Storage access may be blocked; ignore and fall back to document language.
+  }
+
+  const documentLanguage = document.documentElement.getAttribute('lang');
+  if (documentLanguage && translations[documentLanguage]) {
+    return documentLanguage;
+  }
+
+  const shortLang = documentLanguage?.slice(0, 2);
+  if (shortLang && translations[shortLang]) {
+    return shortLang;
+  }
+
+  return 'ko';
+};
+
+let currentLanguage = 'ko';
+
+const updateLanguageUI = (lang) => {
+  const dropdown = document.querySelector('.language-dropdown');
+  if (!dropdown) {
+    return;
+  }
+
+  const button = dropdown.querySelector('.language-button');
+  const flagElement = button?.querySelector('.language-flag');
+  const codeElement = button?.querySelector('.language-code');
+  const config = LANGUAGE_OPTIONS[lang];
+
+  if (button && config) {
+    button.dataset.lang = lang;
+    if (flagElement) {
+      flagElement.textContent = config.flag;
+    }
+    if (codeElement) {
+      codeElement.textContent = config.code;
+    }
+  }
+
+  dropdown.querySelectorAll('.language-option').forEach((option) => {
+    const optionLang = option.dataset.lang;
+    const isActive = optionLang === lang;
+    option.setAttribute('aria-checked', String(isActive));
+    if (isActive) {
+      option.setAttribute('aria-current', 'true');
+    } else {
+      option.removeAttribute('aria-current');
+    }
+  });
+};
+
+const applyTranslations = (lang) => {
+  const dictionary = translations[lang];
+  if (!dictionary) {
+    return;
+  }
+
+  document.documentElement.setAttribute('lang', lang);
+
+  document.querySelectorAll('[data-i18n]').forEach((element) => {
+    const key = element.dataset.i18n;
+    const value = dictionary[key];
+
+    if (value === undefined) {
+      return;
+    }
+
+    const type = element.dataset.i18nType || 'text';
+    if (type === 'html') {
+      element.innerHTML = value;
+    } else {
+      element.textContent = value;
+    }
+  });
+
+  document.querySelectorAll('[data-i18n-aria-label]').forEach((element) => {
+    const key = element.dataset.i18nAriaLabel;
+    const value = dictionary[key];
+
+    if (value === undefined) {
+      return;
+    }
+
+    element.setAttribute('aria-label', value);
+  });
+
+  const pageTitle = dictionary['meta.title'];
+  if (pageTitle) {
+    document.title = pageTitle;
+  }
+
+  const metaDescription = document.querySelector('meta[name="description"]');
+  if (metaDescription && dictionary['meta.description']) {
+    metaDescription.setAttribute('content', dictionary['meta.description']);
+  }
+
+  const ogTitle = document.querySelector('meta[property="og:title"]');
+  if (ogTitle && dictionary['meta.ogTitle']) {
+    ogTitle.setAttribute('content', dictionary['meta.ogTitle']);
+  }
+
+  const ogDescription = document.querySelector('meta[property="og:description"]');
+  if (ogDescription && dictionary['meta.ogDescription']) {
+    ogDescription.setAttribute('content', dictionary['meta.ogDescription']);
+  }
+
+  const ogLocale = document.querySelector('meta[property="og:locale"]');
+  if (ogLocale && dictionary['meta.ogLocale']) {
+    ogLocale.setAttribute('content', dictionary['meta.ogLocale']);
+  }
+};
+
+const setLanguage = (lang, { persist = true } = {}) => {
+  if (!translations[lang]) {
+    return;
+  }
+
+  currentLanguage = lang;
+
+  if (persist) {
+    try {
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, lang);
+    } catch (error) {
+      // Ignore storage errors (e.g., in private mode).
+    }
+  }
+
+  applyTranslations(lang);
+  updateLanguageUI(lang);
+};
+
+const setupLanguageDropdown = () => {
+  const dropdown = document.querySelector('.language-dropdown');
+  const button = dropdown?.querySelector('.language-button');
+  const menu = dropdown?.querySelector('.language-menu');
+
+  if (!dropdown || !button || !menu) {
+    return;
+  }
+
+  const options = Array.from(menu.querySelectorAll('.language-option'));
+
+  const handleDocumentClick = (event) => {
+    if (!dropdown.contains(event.target)) {
+      closeDropdown();
+    }
+  };
+
+  const handleDocumentKeydown = (event) => {
+    if (event.key === 'Escape') {
+      closeDropdown({ returnFocus: true });
+    }
+  };
+
+  const closeDropdown = ({ returnFocus = false } = {}) => {
+    if (dropdown.getAttribute('data-open') !== 'true') {
+      return;
+    }
+
+    dropdown.setAttribute('data-open', 'false');
+    button.setAttribute('aria-expanded', 'false');
+    menu.setAttribute('aria-hidden', 'true');
+    document.removeEventListener('click', handleDocumentClick);
+    document.removeEventListener('keydown', handleDocumentKeydown);
+
+    if (returnFocus) {
+      button.focus();
+    }
+  };
+
+  const openDropdown = () => {
+    if (dropdown.getAttribute('data-open') === 'true') {
+      return;
+    }
+
+    dropdown.setAttribute('data-open', 'true');
+    button.setAttribute('aria-expanded', 'true');
+    menu.setAttribute('aria-hidden', 'false');
+    document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('keydown', handleDocumentKeydown);
+
+    const activeOption = menu.querySelector('.language-option[aria-checked="true"]') || options[0];
+    activeOption?.focus();
+  };
+
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    const isOpen = dropdown.getAttribute('data-open') === 'true';
+    if (isOpen) {
+      closeDropdown();
+    } else {
+      openDropdown();
+    }
+  });
+
+  button.addEventListener('keydown', (event) => {
+    if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openDropdown();
+    }
+  });
+
+  menu.addEventListener('click', (event) => {
+    const option = event.target.closest('.language-option');
+    if (!option) {
+      return;
+    }
+
+    const lang = option.dataset.lang;
+    if (lang) {
+      setLanguage(lang);
+    }
+
+    closeDropdown({ returnFocus: true });
+  });
+
+  menu.addEventListener('keydown', (event) => {
+    const focusable = options;
+    const currentIndex = focusable.indexOf(document.activeElement);
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const nextIndex = (currentIndex + 1) % focusable.length;
+      focusable[nextIndex]?.focus();
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const prevIndex = (currentIndex - 1 + focusable.length) % focusable.length;
+      focusable[prevIndex]?.focus();
+      return;
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault();
+      focusable[0]?.focus();
+      return;
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault();
+      focusable[focusable.length - 1]?.focus();
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      const activeLang = document.activeElement?.dataset?.lang;
+      if (activeLang) {
+        setLanguage(activeLang);
+      }
+      closeDropdown({ returnFocus: true });
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      closeDropdown({ returnFocus: true });
+    }
+  });
+
+  dropdown.setAttribute('data-open', 'false');
+  button.setAttribute('aria-expanded', 'false');
+  menu.setAttribute('aria-hidden', 'true');
+
+  updateLanguageUI(currentLanguage);
+};
+
 const enableSmoothScroll = () => {
   document.querySelectorAll('a[href^="#"]').forEach((link) => {
     link.addEventListener('click', (event) => {
@@ -176,7 +579,10 @@ const setupScrollTopButton = () => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+  const initialLanguage = getInitialLanguage();
+  setLanguage(initialLanguage, { persist: false });
+  setupLanguageDropdown();
   enableSmoothScroll();
   setupNavMenu();
-  setupScrollTopButton(); // ✨ 이 줄을 추가합니다.
+  setupScrollTopButton();
 });

--- a/style.css
+++ b/style.css
@@ -75,18 +75,129 @@ header {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
   height: 64px;
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.nav-actions .nav-toggle {
+  margin-left: 4px;
 }
 
 .primary-nav {
   display: flex;
   align-items: center;
+  margin-left: auto;
 }
 
 .nav-menu {
   display: flex;
   align-items: center;
   gap: 12px;
+}
+
+.language-dropdown {
+  position: relative;
+  z-index: 25;
+}
+
+.language-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(15, 23, 42, 0.65);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  transition: filter 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.language-button:hover {
+  filter: brightness(1.12);
+}
+
+.language-button:active {
+  transform: translateY(1px);
+}
+
+.language-code {
+  font-size: 0.95rem;
+}
+
+.language-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 168px;
+  margin: 0;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 23, 42, 0.92);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  list-style: none;
+  opacity: 0;
+  transform: translateY(-6px);
+  pointer-events: none;
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+}
+
+.language-menu li {
+  list-style: none;
+}
+
+.language-option {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.language-option:hover {
+  background: rgba(99, 102, 241, 0.18);
+}
+
+.language-option[aria-checked='true'] {
+  background: rgba(99, 102, 241, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.45);
+}
+
+.language-option .language-flag {
+  font-size: 1.1rem;
+}
+
+.language-option .language-name {
+  font-size: 0.95rem;
+}
+
+.language-dropdown[data-open='true'] .language-menu {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  visibility: visible;
+}
+
+.language-dropdown[data-open='true'] .language-button {
+  border-color: rgba(99, 102, 241, 0.6);
 }
 
 .nav-toggle {
@@ -348,6 +459,18 @@ h1 {
   .nav-menu .btn-primary {
     width: 100%;
     justify-content: center;
+  }
+
+  .nav-actions {
+    gap: 8px;
+  }
+
+  .language-button {
+    padding: 10px 12px;
+  }
+
+  .language-menu {
+    right: -4px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a header language dropdown and mark navigation/content elements with translation keys
- implement a language manager with Korean and English copy, metadata updates, and dropdown interactions backed by localStorage
- style the dropdown and adjust header layout so the selector works across desktop and mobile breakpoints

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca542d8aac8332a0f8e1915673d082